### PR TITLE
add some saving details about hdf5storage, scipy and h5py

### DIFF
--- a/ReconTutorial/main.py
+++ b/ReconTutorial/main.py
@@ -39,6 +39,9 @@ def savenumpy2mat(data, np_var, filepath):
     np_var: str, the name of the variable in the mat file.
     data: numpy, array to save.
     filepath: str, the path to save the mat file.
+    # attention! hdftstorage save the array in a mat file that both h5py and scipy.io.loadmat can read.
+    # but it will transpose the data array.
+    # If you want to save the file in the same way as the original mat file, please first apply np.transpose(data) 
     '''
     savedict= {}
     savedict[np_var] = data


### PR DESCRIPTION
Some issues I encountered when I tried to submit the docker. Dimension inconsistency occurs when the original mat loading by h5py (as the one in the tutorial and loadFun.py) and by hdf5storage package. You have to transpose the array before saving.

For details, please refer to. 
https://stackoverflow.com/questions/52194210/python-hdf5storage-is-transposing-my-data